### PR TITLE
Sugerindo cálculo de tamanho da fonte dinâmico

### DIFF
--- a/islands/GerarSantinho.tsx
+++ b/islands/GerarSantinho.tsx
@@ -112,20 +112,14 @@ export default function GerarSantinho({ candidatos, uf }: Props) {
 
             const nomeToDraw = nomeUrna ?? "Não escolhido(a)";
             const fontSizeNome = (() => {
-              if (nomeToDraw.length < 5) {
-                return "100";
-              } else if (nomeToDraw.length < 16) {
-                return "75";
-              } else if (nomeToDraw.length < 22) {
-                return "58";
-              } else {
-                return "42";
-              }
+
+              return `${600 - (nomeToDraw.length / 600)}`
+              
             })();
 
-            ctx.font = `bold ${fontSizeNome}px 'Source Sans Pro'`;
+            ctx.font = `bold ${fontSizeNome}% 'Source Sans Pro'`;
 
-            ctx.fillText(nomeToDraw, 372, yNome);
+            ctx.fillText(nomeToDraw, 372, yNome, 600);
             ctx.fillStyle = nomeUrna ? "#000" : "#666";
             ctx.font = `bold 128px 'Source Sans Pro'`;
 

--- a/islands/GerarSantinho.tsx
+++ b/islands/GerarSantinho.tsx
@@ -116,8 +116,10 @@ export default function GerarSantinho({ candidatos, uf }: Props) {
                 return "100";
               } else if (nomeToDraw.length < 16) {
                 return "75";
-              } else {
+              } else if (nomeToDraw.length < 22) {
                 return "58";
+              } else {
+                return "42";
               }
             })();
 


### PR DESCRIPTION
Utilizando a aplicação (maravilhosa, por sinal, parabéns!) percebi que existem alguns nomes de candidatura que são registradas na urna com uma quantidade de caracteres muito grande, o que acabava cortando parte significante da informação no santinho. Um exemplo disso, que foi inclusive o que me fez perceber essa questão, são as candidaturas coletivas, que geralmente são registradas com o nome de uma liderança e o slogan do coletivo, pois o dado referente a esse aspecto não é mantido pelo TSE e existe a necessidade do registro de nome da liderança unido ao nome da chapa.

Assim, sugeri a realização de um cálculo dinâmico que calcula a fonte com base em um tamanho de largura estabelecido e um cálculo de porcentagem com base na largura total e o número de caracteres do nome, sendo possível manter certa legibilidade para a totalidade dos nomes na imagem. 